### PR TITLE
Updated Enable-LocationServices Function

### DIFF
--- a/Autopilot/Set-WindowsTimeZone.ps1
+++ b/Autopilot/Set-WindowsTimeZone.ps1
@@ -145,11 +145,18 @@ Process {
             New-Item -Path $LocationServiceStatusRegValue -Force | Out-Null
         }
 
-        $LocationServiceStatusValue = Get-ItemPropertyValue -Path $LocationServiceStatusRegValue -Name "Status"
-        Write-LogEntry -Value "Checking registry value 'Status' configuration in key: $($LocationServiceStatusRegValue)" -Severity 1
-        if ($LocationServiceStatusValue -ne 1) {
-            Write-LogEntry -Value "Registry value 'Status' configuration mismatch detected, setting value to: 1" -Severity 1
-            Set-ItemProperty -Path $LocationServiceStatusRegValue -Name "Status" -Type "DWord" -Value 1 -Force
+        $LocationServiceStatusRegDWORD = Get-ItemProperty -Path $LocationServiceStatusRegValue -Name "Status" -ErrorAction SilentlyContinue
+        if (!$LocationServiceStatusRegDWORD) {
+            Write-LogEntry -Value "Presence of 'Status' was not detected in key: $LocationServiceStatusRegValue, attempting to create it" -Severity 1
+            New-ItemProperty -Path $LocationServiceStatusRegValue -Name "Status" -Type "DWord" -Value 1 -Force
+        }
+        else {
+            $LocationServiceStatusValue = Get-ItemPropertyValue -Path $LocationServiceStatusRegValue -Name "Status" -ErrorAction SilentlyContinue
+            Write-LogEntry -Value "Checking registry value 'Status' configuration in key: $($LocationServiceStatusRegValue)" -Severity 1
+            if ($LocationServiceStatusValue -ne 1) {
+                Write-LogEntry -Value "Registry value 'Status' configuration mismatch detected, setting value to: 1" -Severity 1
+                Set-ItemProperty -Path $LocationServiceStatusRegValue -Name "Status" -Type "DWord" -Value 1 -Force
+            }
         }
 
         $LocationService = Get-Service -Name "lfsvc"


### PR DESCRIPTION
Added the ability for the script to check to see if the 'Status' DWORD exists under HKLM:\SYSTEM\CurrentControlSet\Services\lfsvc\Service\Configuration
If it exists, it'll check the value. If it doesn't exist, it'll create it with the correct value. Previously, it didn't exist on new Windows 10 Machines and the script would fail since it never created it and only checked for the value.