### PR TITLE
Fix $TokenExpierMins and $BitlockerRecoveryKeys

### DIFF
--- a/Security/Get-IntuneManagedDeviceBitLockerKeyPresence.ps1
+++ b/Security/Get-IntuneManagedDeviceBitLockerKeyPresence.ps1
@@ -172,7 +172,7 @@ Process {
                     $UTCDateTime = (Get-Date).ToUniversalTime()
     
                     # Determine the token expiration count as minutes
-                    $TokenExpireMins = ([datetime]$Headers["ExpiresOn"] - $UTCDateTime).Minutes
+                    $TokenExpireMins = (([datetime]$Headers["ExpiresOn"]).ToUniversalTime() - $UTCDateTime).Minutes
     
                     # Attempt to retrieve a refresh token when token expiration count is less than or equal to 10
                     if ($TokenExpireMins -le 10) {
@@ -332,7 +332,7 @@ Process {
         $AuthenticationHeader = New-AuthenticationHeader -AccessToken $AccessToken
         
         # Retrieve all available BitLocker recovery keys, select only desired properties
-        $BitLockerRecoveryKeys = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "bitlocker/recoveryKeys?`$select=id,createdDateTime,deviceId" -Headers $AuthenticationHeader -Verbose:$VerbosePreference
+        $BitLockerRecoveryKeys = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "informationProtection/bitlocker/recoveryKeys?`$select=id,createdDateTime,deviceId" -Headers $AuthenticationHeader -Verbose:$VerbosePreference
         
         # Retrieve all managed Windows devices in Intune
         $ManagedDevices = Invoke-MSGraphOperation -Get -APIVersion "v1.0" -Resource "deviceManagement/managedDevices?`$filter=operatingSystem eq 'Windows'&select=azureADDeviceId&`$select=deviceName,id,azureADDeviceId" -Headers $AuthenticationHeader -Verbose:$VerbosePreference


### PR DESCRIPTION
Fix for: https://github.com/MSEndpointMgr/Intune/issues/36 

Update the check for expiration of $Header["ExpiresOn"]

Update the URL for bitlocker to use the new one.