### PR TITLE
Update PSIntuneAuth.psm1

### DIFF
--- a/Modules/PSIntuneAuth/PSIntuneAuth.psm1
+++ b/Modules/PSIntuneAuth/PSIntuneAuth.psm1
@@ -166,7 +166,7 @@ function Get-MSIntuneAuthToken {
                 # Check if multiple modules exist and determine the module path for the most current version
                 if (($AzureADModules | Measure-Object).Count -gt 1) {
                     $LatestAzureADModule = ($AzureADModules | Select-Object -Property Version | Sort-Object)[-1]
-                    $AzureADModulePath = $AzureADModules | Where-Object { $_.Version -like $LatestAzureADModule.Version } | Select-Object -ExpandProperty ModuleBase
+                    $AzureADModulePath = $AzureADModules | Where-Object { $_.Version -like $LatestAzureADModule.Version } | Select-Object -First 1 -ExpandProperty ModuleBase
                 }
                 else {
                     $AzureADModulePath = $AzureADModules | Select-Object -ExpandProperty ModuleBase


### PR DESCRIPTION
For some strange reason i had 3 installed versions of the latest AzureAD module and when it tried to join-path in line 178 it failed because there where 3 $AzureADModulePath. Adding -First 1 in line 169 it gets 1 of them.